### PR TITLE
Clarify initial governance steps

### DIFF
--- a/Governance.md
+++ b/Governance.md
@@ -1,0 +1,11 @@
+# Magma governance
+
+## Technical Committee
+
+The Technical Committee (TC) is comprised of 5 members who are responsible for architectural decisions and making final decisions if Maintainers cannot come to an agreement. The initial members will be appointed to 12 month terms with a goal of moving to an elected TC membership within 24 months. Once elections begin, the elections will be staggered so that only a portion of the TC seats is up for election in each cycle. 
+
+There are no term limits, but in order to encourage diversity, no more than 2 of the 5 seats can be filled by any one organization. The TC will meet regularly in an open forum with times and locations published in community channels.
+
+The exact size and model for the TC may evolve over time based on the needs and growth of the project, but the governing body will always be committed to openness, diversity and the principle that technical decisions are made by technical contributors.
+
+**Any individual may hold multiple roles simultaneously such as being a Maintainer and a member of the TC.**

--- a/Governance.md
+++ b/Governance.md
@@ -1,11 +1,45 @@
 # Magma governance
 
-## Technical Committee
+Magma is committed to implementing the
+[Four Opens](https://www.openstack.org/four-opens/): Open source, Open
+development, Open design and Open community. An open governance model, where
+technical decisions are made by technical contributors and a representative
+body accessible to every contributor, is a critical part in establishing a
+truly open community.
 
-The Technical Committee (TC) is comprised of 5 members who are responsible for architectural decisions and making final decisions if Maintainers cannot come to an agreement. The initial members will be appointed to 12 month terms with a goal of moving to an elected TC membership within 24 months. Once elections begin, the elections will be staggered so that only a portion of the TC seats is up for election in each cycle. 
+Magma's project open governance model will be put in place in several steps,
+in order to give time for the common team to form from various corporate
+workgroups, and to allow natural leaders to emerge.
 
-There are no term limits, but in order to encourage diversity, no more than 2 of the 5 seats can be filled by any one organization. The TC will meet regularly in an open forum with times and locations published in community channels.
+## Step 1 (current): Interim governance
 
-The exact size and model for the TC may evolve over time based on the needs and growth of the project, but the governing body will always be committed to openness, diversity and the principle that technical decisions are made by technical contributors.
+At this early stage in the formation of the project, Magma is currently
+operating with minimal viable governance. Early critical project decisions
+are generally made in two areas: approving code changes for inclusion into
+Magma, and early release and roadmap decisions.
 
-**Any individual may hold multiple roles simultaneously such as being a Maintainer and a member of the TC.**
+For the first area, Magma uses GitHub maintainers groups. New maintainers
+must be nominated and approved by established maintainers through a simple
+majority with no existing maintainer objecting.
+
+For the second area, Magma uses a Release Management team, with the following
+individuals:
+
+- Michael Callahan
+- Jacky Tian (@xjtian)
+- Sanaz Bazargan
+
+Addition of new members requires approval of all current release management
+team members.
+
+## Step 2: Initial governance
+
+Magma will initially be governed by a Technical Committee with members
+appointed by Magma’s 3 sponsoring organizations, OIA, TIP and OIF. At that
+point, the TC will be responsible for further updates to Governance documents.
+
+This initial TC will be tasked with:
+
+- appointing additional TC members as natural leaders emerge
+- establishing initial operating procedures and governance for the project
+- handling the transition to a fully-elected representation in the future

--- a/Organization_of_Work.md
+++ b/Organization_of_Work.md
@@ -1,0 +1,21 @@
+# Organization of work in Magma development
+
+## Roles
+
+### Contributors
+
+Anyone can become a Contributor by submitting a pull request to the project
+and having that change accepted through the project’s review process. A
+Contributor is someone who has had code merged within the last 12 months.
+Contributors are eligible to vote in governance elections. Contributors have
+access to propose and review code but not merge the code into repos of the
+project.
+
+### Maintainers
+
+A Maintainer has the ability to merge code into the project. Maintainers are
+active Contributors and participants in the project. In order to become a
+Maintainer, you must be nominated and approved by the established Maintainers,
+through a simple majority vote with no existing maintainer objecting.
+Within the project, sub-components may decide to have additional requirements
+for the review of code in their repos.

--- a/README.md
+++ b/README.md
@@ -16,34 +16,26 @@ Magma is an open-source software platform that gives network operators an open, 
   - [Magma](https://magmacore.slack.com) workspace
   - [Slack Invite](https://join.slack.com/t/magmacore/shared_invite/zt-g76zkofr-g6~jYiS3KRzC9qhAISUC2A)
 
-See the [CONTRIBUTING](CONTRIBUTING.md) file for how to help out.
+All community members should abide to our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-# Governance
+## Contributing to Magma
 
-Magma strives to operate under an open governance model that encourages contribution and participation from all interested organizations and developers. Technical decisions are made by technical contributors and a representative Technical Committee. The community is committed to diversity, openness, and encouraging new contributors and leaders to rise up.
+See the [CONTRIBUTING](CONTRIBUTING.md) file for information on how to help
+out.
 
-## Development Roles
+See the [Code review guidelines](Reviewing.md) to help with PR reviews.
 
-### Contributors
+## Organization of work
 
-Anyone can become a Contributor by submitting code to the project and having that code accepted through the project’s review process. A Contributor is someone who has had code merged within the last 12 months. Contributors are eligible to vote in the Technical Committee elections. Contributors have access to propose and review code but not merge the code into repos of the project.
+See the [Organization of work](Organization_of_Work.md) for a description of
+the various roles involved in development and the various workgroups that we
+use.
 
-### Maintainers
+## Governance
 
-A Maintainer has the ability to merge code into the project. Maintainers are active Contributors and participants in the project. In order to become a Maintainer, you must be nominated and approved by the established Maintainers. Within the project, sub-components may decide to have additional requirements for the review of code in their repos.
+Magma strives to operate under an open governance model that encourages
+contribution and participation from all interested organizations and
+developers.
 
-### Code review process
-All pull requests require 2 approvals from maintainers for commits as a starting point. Sub groups can evolve this based on what works.
-
-### Maintainers nominations
-Maintainers must be nominated and approved by established maintainers through a simple majority with no existing maintainer objecting.
-
-## Technical Committee
-
-The Technical Committee (TC) is comprised of 5 members who are responsible for architectural decisions and making final decisions if Maintainers cannot come to an agreement. The initial members will be appointed to 12 month terms with a goal of moving to an elected TC membership within 24 months. Once elections begin, the elections will be staggered so that only a portion of the TC seats is up for election in each cycle. 
-
-There are no term limits, but in order to encourage diversity, no more than 2 of the 5 seats can be filled by any one organization. The TC will meet regularly in an open forum with times and locations published in community channels.
-
-The exact size and model for the TC may evolve over time based on the needs and growth of the project, but the governing body will always be committed to openness, diversity and the principle that technical decisions are made by technical contributors.
-
-**Any individual may hold multiple roles simultaneously such as being a Maintainer and a member of the TC.**
+See [Project governance](Governance.md) for an explanation of how decisions
+are made in Magma.


### PR DESCRIPTION
Refactor the README into a set of documents and clarify the initial governance steps, as discussed in various meetings.