### PR TITLE
Rewrite before archiving

### DIFF
--- a/Governance.md
+++ b/Governance.md
@@ -1,34 +1,9 @@
-# Magma governance
+# Archived Repository
 
-Magma is committed to implementing the
-[Four Opens](https://www.openstack.org/four-opens/): Open source, Open
-development, Open design and Open community. An open governance model, where
-technical decisions are made by technical contributors and a representative
-body accessible to every contributor, is a critical part in establishing a
-truly open community.
+In order to consolidate documents related to governance, so that we there is no confusion about which is canonical:
 
-Magma's open technical governance, as detailed in its [Technical Charter](https://github.com/magma/tsc/blob/main/CHARTER.md), is built around the
-the following model:
+* Any content in this repository that is still useful has been merged into [magma/magma](https://github.com/magma/magma/).
+* This document has been rewritten.
+* This repository has been archived.
 
-## Contributers
-
-Anyone may become a contributer to the Magma project.  A contributer is someone who contributes code to the prject github repository, initiates or comments on github issues or contributes to the project in any other way.  Magma's contributers are its community.
-
-## Committers
-
-Committers are contributers who have earned the right to make modifications to the Magma github repository, as set forth in the [CONTRIBUTING file](https://github.com/magma/community/blob/main/CONTRIBUTING.md).  Committers are able to merge code or otherwise modify the Magma github repository.  Committers may be added to or removed from the project by a majority vote of existing committers, with no single committer objecting.
-
-Issues may be raised to the Committers on the "#goverance-committers-ama" channel on the Magma Slack
-
-## The Technical Steering Committee
-
-The Committers of the project will elect 5 of their members to serve as a Technical Steering Committee (TSC) for the project.  The TSC will be responsible for all technical oversight of the project.
-
-As of March 11, 2021, the project TSC members are:
-- Hunter Gatewood (hcgatewood)
-- Marie Bremner (@themarwhal)
-- Raphael Defosseux (@rdefosse)
-- Scott Moeller (@electronjoe)
-- Pravin Shelar (@pshelar)
-
-Issues may be raised to the TSC on the "#goverance-tsc-ama" channel on the Magma Slack
+Note that all earlier content is still available in Git history.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Archived Repository
 
-In order to move to a monorepo model:
+In order to consolidate documents related to governance, so that we there is no confusion about which is canonical:
 
 * Any content in this repository that is still useful has been merged into [magma/magma](https://github.com/magma/magma/).
-* This README has been rewritten.
+* This document has been rewritten.
 * This repository has been archived.
 
-
+Note that all earlier content is still available in Git history.


### PR DESCRIPTION
Rewrite in advance of archiving so that document contents reflect the reason for the change and how users can find the old content.

Signed-off-by: Lucas Gonze <lucas@gonze.com>
